### PR TITLE
feat: Twemoji 적용 및 사이드바 클릭 시 렌더되지 않던 현상 수정

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -142,7 +142,7 @@ const config = {
         maxHeadingLevel: 4,
       },
       zoom: {
-        selector: '.markdown img',
+        selector: '.markdown img:not(.emoji)',
         background: {
           light: 'rgb(255, 255, 255)',
           dark: 'rgb(50, 50, 50)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "docusaurus-plugin-image-zoom": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "twemoji": "^14.0.2"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.4.0",
@@ -13505,6 +13506,62 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+    },
+    "node_modules/twemoji": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-14.0.2.tgz",
+      "integrity": "sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==",
+      "dependencies": {
+        "fs-extra": "^8.0.1",
+        "jsonfile": "^5.0.0",
+        "twemoji-parser": "14.0.0",
+        "universalify": "^0.1.2"
+      }
+    },
+    "node_modules/twemoji-parser": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-14.0.0.tgz",
+      "integrity": "sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA=="
+    },
+    "node_modules/twemoji/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/twemoji/node_modules/fs-extra/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/twemoji/node_modules/jsonfile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
+      "dependencies": {
+        "universalify": "^0.1.2"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/twemoji/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/type-fest": {
       "version": "2.19.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "docusaurus-plugin-image-zoom": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "twemoji": "^14.0.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.4.0",

--- a/src/components/ApplyTwemoji.js
+++ b/src/components/ApplyTwemoji.js
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import { useLocation } from '@docusaurus/router';
+import twemoji from 'twemoji';
+
+const ApplyTwemoji = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    const observer = new MutationObserver((mutationsList, observer) => {
+      twemoji.parse(document.body);
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [location]);
+  return null;
+};
+
+export default ApplyTwemoji;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,3 +36,10 @@
 html {
   scroll-behavior: smooth;
 }
+
+img.emoji {
+  height: 1em;
+  width: 1em;
+  margin: 0 .05em 0 .1em;
+  vertical-align: -0.1em;
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ApplyTwemoji from '/src/components/ApplyTwemoji';
+
+function Root({ children }) {
+  return (
+    <>
+      {children}
+      <ApplyTwemoji />
+    </>
+  );
+}
+
+export default Root;


### PR DESCRIPTION
애플과 윈도우, 갤럭시 등의 이모지 표현 방식이 모두 다릅니다. 이를 통일하고자 Twemoji를 활용했습니다. 스크립트를 활용해 이모지를 twemoji로 바꾸는 게 있는데, 이게 적용이 처음에는 안 됐습니다. docusaurus에서 js를 통해 문서들을 불러오는 것 같더라고요 😅 twemoji의 스크립트가 먼저 실행되기도 하고, 네비게이션 바에서 이동하는 방식이 페이지 풀 로드가 아니라 적용되지 않기도 했습니다. gpt랑 대화한 끝에 이렇게 적용해 보았는데, 프론트 분들이 보시기에 괜찮은 방식인지 궁금해요. 아마 Docusaurus 쪽 코드의 이해도 필요할 거라, 추가된 부분이 현재 웹사이트를 운영하는 데에 무난하다고만 생각되면 괜찮아요.

기능이다 보니 이 부분은 코드를 한 번 봐주시면 좋겠습니다 😄

`npm install -> npm start`로 확인해보실 수 있어용

as-is
<img width="243" alt="image" src="https://github.com/review-me-blog/review-me-blog.github.io/assets/31026350/87b77d9b-cd07-4661-95ed-f3723415c10f">

to-be
<img width="264" alt="image" src="https://github.com/review-me-blog/review-me-blog.github.io/assets/31026350/4c18c2aa-fbe8-4686-9e6e-fdf0382506e0">
