### PR TITLE
fix: 이모지 불러오지 못하는 현상 수정

### DIFF
--- a/src/components/ApplyTwemoji.js
+++ b/src/components/ApplyTwemoji.js
@@ -7,7 +7,7 @@ const ApplyTwemoji = () => {
 
   useEffect(() => {
     const observer = new MutationObserver((mutationsList, observer) => {
-      twemoji.parse(document.body);
+      twemoji.parse(document.body, {base: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/"});
     });
     observer.observe(document.body, { childList: true, subtree: true });
     return () => observer.disconnect();


### PR DESCRIPTION
Twemoji의 base url maxcdn.com이 닫혀 사용하지 못하던 오류를 아래 링크로 수정합니다.
`https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2`

### Preview
<img width="161" alt="image" src="https://github.com/review-me-blog/review-me-blog.github.io/assets/31026350/76c26fe7-595c-47f0-9484-19301803ba40">
