### PR TITLE
fix: CD Page 배포 cname 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,3 +33,4 @@ jobs:
         with:
           github_token: ${{ secrets.DEPLOY_TOKEN }}
           publish_dir: ./build
+          cname: blog.review-me.page


### PR DESCRIPTION
기존 CD 스크립트가 실행되면 페이지 링크가 `github.io`로 초기화되던 문제를 수정합니다. [reference](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-add-cname-file-cname)