### PR TITLE
fix : 블로그에서 리뷰미 시연 영상 오류 수정

### DIFF
--- a/blog/2024-08-26-release-version-1/index.mdx
+++ b/blog/2024-08-26-release-version-1/index.mdx
@@ -129,6 +129,7 @@ import writingImg from "./image/writing.jpg";
 
 # 리뷰미 version 1.0.0 소개
 
+[🌟 리뷰미 배포 사이트 바로가기](https://review-me.page/)
 [📹리뷰미 시연 영상 보러가기](https://github.com/woowacourse-teams/2024-review-me/wiki/REVIEW-ME-1.0.0-%EB%B0%B0%ED%8F%AC-%EC%8B%9C%EC%97%B0-%EC%98%81%EC%83%81)
 
 ## 기능 소개

--- a/blog/2024-08-26-release-version-1/index.mdx
+++ b/blog/2024-08-26-release-version-1/index.mdx
@@ -130,7 +130,16 @@ import writingImg from "./image/writing.jpg";
 # 리뷰미 version 1.0.0 소개
 
 [🌟 리뷰미 배포 사이트 바로가기](https://review-me.page/)
-[📹리뷰미 시연 영상 보러가기](https://github.com/woowacourse-teams/2024-review-me/wiki/REVIEW-ME-1.0.0-%EB%B0%B0%ED%8F%AC-%EC%8B%9C%EC%97%B0-%EC%98%81%EC%83%81)
+
+## 시연 영상
+
+<video width="600px" controls>
+  <source
+    src="https://private-user-images.githubusercontent.com/69838872/361453327-709fbbd3-69e3-4b98-86ab-dda7ba28bd1a.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjQ2ODM1NzgsIm5iZiI6MTcyNDY4MzI3OCwicGF0aCI6Ii82OTgzODg3Mi8zNjE0NTMzMjctNzA5ZmJiZDMtNjllMy00Yjk4LTg2YWItZGRhN2JhMjhiZDFhLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODI2VDE0NDExOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTg1Y2NjNWFlZTE0MWU2MGY5MGJkZWMxZDNmYTI2ZmU0MTgzYWNhYjE2MTg2Njk4OGU4ODEwYzA5NmE2MTc0YmEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.-4VGTpr2u5-ynSWmcKHWZ3NBsnh6Bd_JeM24qMKTIjw"
+    type="video/mp4"
+    alt="리뷰미 version 1.0.0 시연 영상"
+  />
+</video>
 
 ## 기능 소개
 

--- a/blog/2024-08-26-release-version-1/index.mdx
+++ b/blog/2024-08-26-release-version-1/index.mdx
@@ -129,18 +129,7 @@ import writingImg from "./image/writing.jpg";
 
 # 리뷰미 version 1.0.0 소개
 
-## 시연 영상
-
-<div style={{ width: "100%", display: "flex", justifyContent: "center" }}>
-  <video width="600px" controls>
-    <source
-      src="https://private-user-images.githubusercontent.com/69838872/361453327-709fbbd3-69e3-4b98-86ab-dda7ba28bd1a.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjQ2ODA0NjksIm5iZiI6MTcyNDY4MDE2OSwicGF0aCI6Ii82OTgzODg3Mi8zNjE0NTMzMjctNzA5ZmJiZDMtNjllMy00Yjk4LTg2YWItZGRhN2JhMjhiZDFhLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA4MjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwODI2VDEzNDkyOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTI2M2JlZmFkNTM5NTliZmQzNWYyNWJjZDJkYzEwMzA5MjdhY2NhMDljNWE5ZTU2NjBkNzkxNzUxMjA0YjdjYWYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.cvkjIa7PVsUNyvELU6taw-pW7mAfTH_rXq_2Ka79yhE"
-      type="video/mp4"
-      alt="리뷰미 version 1.0.0 시연 영상"
-    />
-
-  </video>
-</div>
+[📹리뷰미 시연 영상 보러가기](https://github.com/woowacourse-teams/2024-review-me/wiki/REVIEW-ME-1.0.0-%EB%B0%B0%ED%8F%AC-%EC%8B%9C%EC%97%B0-%EC%98%81%EC%83%81)
 
 ## 기능 소개
 


### PR DESCRIPTION
로컬에서 문제 없던 리뷰미 시연 영상이, 블로그에서 재생되지 않는 오류가 발생했어요.
video의 src 문제라고 추측해서 src를 변경해봤어요. 
이것도 되지 않는다면 리뷰미 시연 영상이 있는 wiki 주소 링크를 만들 예정이에요.

오류를 수정하면서 리뷰미 배포 사이트 주소도 추가했어요.